### PR TITLE
Added OperationalData of the Event

### DIFF
--- a/ZabbixClient/Entities/Event.cs
+++ b/ZabbixClient/Entities/Event.cs
@@ -138,6 +138,12 @@ namespace ZabbixClient.Entities
         /// 1 - event is suppressed.
         /// </summary>
         public Suppressed suppressed { get; set; }
+
+		/// <summary>
+		/// Operational data with expanded macros.
+		/// </summary>
+		public string opdata { get; set; }
+
         #endregion
 
         #region Associations

--- a/ZabbixClient/Entities/Trend.cs
+++ b/ZabbixClient/Entities/Trend.cs
@@ -1,0 +1,49 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using ZabbixClient.Helper;
+
+namespace ZabbixClient.Entities
+{
+    public partial class Trend : EntityBase
+    {
+        #region Properties
+        /// <summary>
+        /// Time when that value was received.
+        /// </summary>
+        [JsonConverter(typeof(TimestampToDateTimeConverter))]
+        public DateTime clock { get; set; }
+
+        /// <summary>
+        /// ID of the related item.
+        /// </summary>
+        [JsonProperty("itemid")]
+        public override string Id { get; set; }
+
+		/// <summary>
+		/// Number of values that were available for the hour.
+		/// </summary>
+		public int num { get; set; }
+
+		/// <summary>
+		/// Hourly minimum value.
+		/// </summary>
+		public float value_min { get; set; }
+
+		/// <summary>
+		/// Hourly average value.
+		/// </summary>
+		public float value_avg { get; set; }
+
+		/// <summary>
+		/// Hourly maximum value.
+		/// </summary>
+		public float value_max { get; set; }
+
+		#endregion
+
+	}
+}

--- a/ZabbixClient/IContext.cs
+++ b/ZabbixClient/IContext.cs
@@ -53,8 +53,9 @@ namespace ZabbixClient
         ITemplateScreenItemService TemplateScreenItems { get; }
         ITemplateScreenService TemplateScreens { get; }
         ITemplateService Templates { get; }
-        ITriggerPrototypeService TriggerPrototypes { get; }
-        ITriggerService Triggers { get; }
+		ITrendService Trends { get; }
+		ITriggerPrototypeService TriggerPrototypes { get; }
+		ITriggerService Triggers { get; }
         IUserGroupService UserGroups { get; }
         IGlobalMacroService GlobalMacros { get; }
         IHostMacroService HostMacros { get; }
@@ -152,7 +153,8 @@ namespace ZabbixClient
             TemplateScreenItems = new TemplateScreenItemService(this);
             TemplateScreens = new TemplateScreenService(this);
             Templates = new TemplateService(this);
-            TriggerPrototypes = new TriggerPrototypeService(this);
+			Trends = new TrendService(this);
+            TriggerPrototypes = new TriggerPrototypeService(this); 
             Triggers = new TriggerService(this);
             UserGroups = new UserGroupService(this);
             GlobalMacros = new GlobalMacroService(this);
@@ -300,8 +302,9 @@ namespace ZabbixClient
         public ITemplateScreenItemService TemplateScreenItems { get; private set; }
         public ITemplateScreenService TemplateScreens { get; private set; }
         public ITemplateService Templates { get; private set; }
-        public ITriggerPrototypeService TriggerPrototypes { get; private set; }
-        public ITriggerService Triggers { get; private set; }
+		public ITrendService Trends { get; private set; }
+		public ITriggerPrototypeService TriggerPrototypes { get; private set; }
+		public ITriggerService Triggers { get; private set; }
         public IUserGroupService UserGroups { get; private set; }
         public IGlobalMacroService GlobalMacros { get; private set; }
         public IHostMacroService HostMacros { get; private set; }

--- a/ZabbixClient/Services/TrendService.cs
+++ b/ZabbixClient/Services/TrendService.cs
@@ -1,0 +1,72 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using ZabbixClient.Entities;
+using ZabbixClient.Helper;
+using ZabbixClient;
+
+namespace ZabbixClient.Services
+{
+	public interface ITrendService
+	{
+		//IEnumerable<Trend> Get(/*object filter = null,*/ IEnumerable<TrendInclude> include = null, Dictionary<string, object> @params = null);
+		IEnumerable<Trend> GetByItem(string itemid, /*IEnumerable<TrendInclude> include = null,*/ Dictionary<string, object> @params = null);
+		IEnumerable<Trend> GetByItems(IEnumerable<string> itemids, /*IEnumerable<TrendInclude> include = null,*/ Dictionary<string, object> @params = null);
+		IEnumerable<Trend> GetByItemFrom(string itemid, DateTime from, /*IEnumerable<TrendInclude> include = null,*/ Dictionary<string, object> @params = null);
+		IEnumerable<Trend> GetByItemsFrom(IEnumerable<string> itemids, DateTime from, /*IEnumerable<TrendInclude> include = null,*/ Dictionary<string, object> @params = null);
+	}
+
+	public class TrendService : ServiceBase<Trend, TrendInclude>, ITrendService
+	{
+		public TrendService(IContext context) : base(context, "trend") { }
+
+		protected override Dictionary<string, object> BuildParams(object filter = null, IEnumerable<TrendInclude> include = null, Dictionary<string, object> @params = null)
+		{
+			var includeHelper = new IncludeHelper(include == null ? 1 : include.Sum(x => (int)x));
+			if (@params == null)
+				@params = new Dictionary<string, object>();
+
+			@params.AddIfNotExist("output", "extend");
+
+			//Filter is not part of the parameters (yet, in 6.0 and 7.0)
+			//@params.AddOrReplace("filter", filter);
+
+			return @params;
+		}
+
+		public IEnumerable<Trend> GetByItem(string itemid, Dictionary<string, object> @params = null)
+		{
+			return GetByItems(new[] { itemid }, @params);
+		}
+		public IEnumerable<Trend> GetByItems(IEnumerable<string> itemids, Dictionary<string, object> @params = null)
+		{
+			@params = @params ?? new Dictionary<string, object>();
+			@params.AddOrReplace("itemids", itemids);
+
+			return Get(filter: null, include: null, @params: @params);
+		}
+
+		public IEnumerable<Trend> GetByItemFrom(string itemid, DateTime from, Dictionary<string, object> @params = null)
+		{
+			return GetByItemsFrom(new[] { itemid }, from, @params);
+		}
+		public IEnumerable<Trend> GetByItemsFrom(IEnumerable<string> itemids, DateTime from, Dictionary<string, object> @params = null)
+		{
+			@params = @params ?? new Dictionary<string, object>();
+			@params.AddOrReplace("itemids", itemids);
+			@params.AddOrReplace("time_from", from.ToTimestamp());
+
+			return Get(filter: null, include: null, @params: @params);
+		}
+
+
+	}
+
+	public enum TrendInclude
+	{
+		All = 1,
+		None = 2
+	}
+}


### PR DESCRIPTION
Since Zabbix 5.0 there exists a new column 'opdata' in an Event.
This holds the operational data of an event.
In this pull request I have added this column and tested it with Zabbix 6.0.25